### PR TITLE
add as.numeric call to food ifelse

### DIFF
--- a/R/specific-gravity.R
+++ b/R/specific-gravity.R
@@ -43,7 +43,7 @@ SGConverter <- function(row) {
 #' @param row a row from a data.frame object
 #' @returns either the value of `weight_g` column for row or dispatches row to `sg_liquidfood_converter`
 sg_food_converter <- function(row) {
-    return(ifelse(!is.na(row[['weight_g']]), row[['weight_g']], sg_liquidfood_converter(row)))
+    return(ifelse(!is.na(row[['weight_g']]), as.numeric(row[['weight_g']]), sg_liquidfood_converter(row)))
 }
 
 #' Specific gravity liquid converter


### PR DESCRIPTION
this keeps it consistent with all other functions here.

This is to get the behaviour right for:

```R
apply(test_data, 1, SGConverter)
```

However this isn't a good way to do this as it coerces types into characters. A better way to do this is coming in another PR.