### PR TITLE
Fix NPMScore output

### DIFF
--- a/R/npm-scoring.R
+++ b/R/npm-scoring.R
@@ -102,7 +102,7 @@ NPMScore <- function(row, sg_adjusted_label) {
                 NA
             }
 
-    score_df <- cbind(energy_score, sugar_score, fat_score, protein_score, fvn_score, fibre_score)
+    score_df <- as.data.frame(cbind(energy_score, sugar_score, fat_score, protein_score, fvn_score, fibre_score))
 
     return(score_df)
 

--- a/R/npm-scoring.R
+++ b/R/npm-scoring.R
@@ -98,7 +98,7 @@ NPMScore <- function(row, sg_adjusted_label) {
                 NPM_score_function(row[['fruit_nut_measurement_percent']], "fvn")
 
                 } else {
-                warning(paste0("Unable to calculate 'sugar' score for product ", row[['name']], " defaulting to NA"))
+                warning(paste0("Unable to calculate 'fruit/veg/nut' score for product ", row[['name']], " defaulting to NA"))
                 NA
             }
 

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -19,4 +19,5 @@ test_that("test full workflow", {
     # grateful for help with this function from https://stackoverflow.com/questions/75825126/conditionally-running-a-function-on-a-row-based-on-values-in-another-column-usin/75825163#75825163
     npm_scores <- do.call("rbind", lapply(seq_len(nrow(test_data)), \(i) NPMScore(test_data[i,], sg_adjusted_label="sg_adjusted")))
 
+    expect_true(is.data.frame(npm_scores))
 })

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -17,6 +17,6 @@ test_that("test full workflow", {
     test_data['sg_adjusted'] <- unlist(lapply(seq_len(nrow(test_data)), \(i) SGConverter(test_data[i, ])))
 
     # grateful for help with this function from https://stackoverflow.com/questions/75825126/conditionally-running-a-function-on-a-row-based-on-values-in-another-column-usin/75825163#75825163
-    npm_scores <- unlist(lapply(seq_len(nrow(test_data)), \(i) NPMScore(test_data[i,], sg_adjusted_label="sg_adjusted")))
+    npm_scores <- do.call("rbind", lapply(seq_len(nrow(test_data)), \(i) NPMScore(test_data[i,], sg_adjusted_label="sg_adjusted")))
 
 })

--- a/tests/testthat/test-npm-scoring.R
+++ b/tests/testthat/test-npm-scoring.R
@@ -172,10 +172,18 @@ test_that("NPMScore returns NA for invalid measurements", {
   )
 
   # expect warnings
-  expect_warning(NPMScore(row, "adjusted_weight"))
-  
+  warns <- capture_warnings(NPMScore(row, "adjusted_weight"))
+
+  expect_match(warns, "Unable to calculate 'energy' score for product test NA product defaulting to NA", all = FALSE)
+  expect_match(warns, "Unable to calculate 'sugar' score for product test NA product defaulting to NA", all = FALSE)
+  expect_match(warns, "Unable to calculate 'salt' score for product test NA product defaulting to NA", all = FALSE)
+  expect_match(warns, "Unable to calculate 'protein' score for product test NA product defaulting to NA", all = FALSE)
+  expect_match(warns, "Unable to calculate 'fibre' score for product test NA product defaulting to NA", all = FALSE)
+  expect_match(warns, "Unable to calculate 'fat' score for product test NA product defaulting to NA", all = FALSE)
+  expect_match(warns, "Unable to calculate 'fruit/veg/nut' score for product test NA product defaulting to NA", all = FALSE)    
+
   # call the function
-  result <- NPMScore(row, "adjusted_weight")
+  result <- suppressWarnings(NPMScore(row, "adjusted_weight"))
   
   # check if the result contains only NA values
   expect_equal(nrow(result), 1)

--- a/tests/testthat/test-npm-scoring.R
+++ b/tests/testthat/test-npm-scoring.R
@@ -148,7 +148,7 @@ test_that("NPMScore returns a data frame with correct column names", {
   result <- NPMScore(row, "adjusted_weight")
   
   # check if the result is a matrix
-  expect_true(is.matrix(result))
+  expect_true(is.data.frame(result))
   
   # check if the column names are correct
   expect_equal(colnames(result), c("energy_score", "sugar_score", "fat_score", "protein_score", "fvn_score", "fibre_score"))


### PR DESCRIPTION
The previous logic of NPMScore returned a matrix object which isn't what we're ideally like when performing this across data.frame objects. The changes here coerce the output of NPMScore to a data.frame so that when using `lapply` to do this row-wise across a data.frame we can squash the data.frames back together using `do.call("rbind", x)` where `x` is the output form a `lapply` like call.