### PR TITLE
remove stopifnot to avoid confusion with errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutrientprofiler
 Title: Nutrient Model Profiler
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: 
     person("Alex", "Coleman", , "a.coleman1@leeds.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7723-3222"))

--- a/R/npm-assess.R
+++ b/R/npm-assess.R
@@ -100,11 +100,6 @@ NPM_total <- function(a_score, c_score, fvn_score, fib_score) {
 #' @returns a character value of either "PASS" or "FAIL"
 NPM_assess <- function(NPM_score, type) {
 
-    stopifnot(
-        "The passed type to NPM_assess does not match expected types " =
-            type %in% c("food","drink")
-    )
-
     assessment <- switch(tolower(type),
         "food" = ifelse(NPM_score >= 4, "FAIL", "PASS"),
         "drink" = ifelse(NPM_score >= 1, "FAIL", "PASS"),


### PR DESCRIPTION
stopifnot duplicates the behaviour of the final catchall in the switch statement so we can remove it.