### PR TITLE
Fix missing saltscore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nutrientprofiler
 Title: Nutrient Model Profiler
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: 
     person("Alex", "Coleman", , "a.coleman1@leeds.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7723-3222"))

--- a/R/npm-assess.R
+++ b/R/npm-assess.R
@@ -16,8 +16,7 @@ NPMAssess <- function(row) {
 
     stopifnot("Score columns not detected. Please ensure you have called NPMScore on your data" = 
         c("energy_score", "sugar_score", "fat_score", 
-        "protein_score", "fvn_score", "fibre_score") %in% names(row)
-        
+        "protein_score", "fvn_score", "fibre_score","sodium_score") %in% names(row)
     )
 
     A_score <- A_scorer(energy_score = row[['energy_score']],

--- a/R/npm-scoring.R
+++ b/R/npm-scoring.R
@@ -102,7 +102,7 @@ NPMScore <- function(row, sg_adjusted_label) {
                 NA
             }
 
-    score_df <- as.data.frame(cbind(energy_score, sugar_score, fat_score, protein_score, fvn_score, fibre_score))
+    score_df <- as.data.frame(cbind(energy_score, sugar_score, fat_score, protein_score, salt_score, fvn_score, fibre_score))
 
     return(score_df)
 

--- a/tests/testthat/test-npm-assess.R
+++ b/tests/testthat/test-npm-assess.R
@@ -32,6 +32,7 @@ assess_row <- data.frame(energy_score = c(5, 3, 4, 6),
                   protein_score = c(4,6,0,2), 
                   fvn_score = c(0,1, 5, 1), 
                   fibre_score = c(1,8, 5, 3), 
+                  sodium_score = c(0, 0, 0, 2),
                   product_type = c("food","food","drink","drink"))
 
 # Test 1: Test if the function returns a matrix
@@ -49,7 +50,7 @@ test_that("NPMAssess should correctly calculate the NPM score", {
 
     out_df <- do.call("rbind", lapply(seq_len(nrow(assess_row)), function(i) NPMAssess(assess_row[i,])))
 
-    expect_true(identical(out_df$NPM_score, c(16,-7,0,9)))
+    expect_true(identical(out_df$NPM_score, c(16,-7,0,11)))
 })
 
 # Test 4: Test if the function correctly assesses the NPM score for a food

--- a/tests/testthat/test-npm-scoring.R
+++ b/tests/testthat/test-npm-scoring.R
@@ -151,7 +151,7 @@ test_that("NPMScore returns a data frame with correct column names", {
   expect_true(is.data.frame(result))
   
   # check if the column names are correct
-  expect_equal(colnames(result), c("energy_score", "sugar_score", "fat_score", "protein_score", "fvn_score", "fibre_score"))
+  expect_equal(colnames(result), c("energy_score", "sugar_score", "fat_score", "protein_score","salt_score", "fvn_score", "fibre_score"))
 })
 
 test_that("NPMScore returns NA for invalid measurements", {


### PR DESCRIPTION
Addresses #39 

When creating the score dataframe from NPMScore we were missing the `salt_score` column. This wasn't picked up by tests and is fixed here as well as in tests.