### PR TITLE
resolves #38: include section on installing from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,17 @@ install.packages("remotes")
 remotes::install_github("Leeds-CDRC/nutrientprofiler")
 ```
 
+You can also download the package as an archive from GitHub and install them
+from source using the following steps. The steps below show how to do this
+directly within R but you can also download an archive of the respository
+directly from the [GitHub releases](https://github.com/Leeds-CDRC/nutrientprofiler/releases) page.
+
+```R
+# download the repository as a .tar.gz archive
+# to your current directory
+download.file("https://github.com/Leeds-CDRC/nutrientprofiler/archive/refs/tags/v0.2.2.tar.gz",
+              dest = "./nutrientprofiler-v0.2.2.tar.gz")
+
+# install the package directly from source
+install.packages("./nutrientprofiler-v0.2.2.tar.gz", repos = NULL, type="source")
+```


### PR DESCRIPTION
This PR introduces updates to the README to outline how to install the package from source without `remotes`