### PR TITLE
Fixes #44 removes inconsistency is naming salt_score column

### DIFF
--- a/R/npm-assess.R
+++ b/R/npm-assess.R
@@ -1,63 +1,68 @@
-
-
 #' NPM assess function
-#' 
-#' This function aims to apply the various scoring functions 
+#'
+#' This function aims to apply the various scoring functions
 #' across a data.frame on a row by row basis.
-#' It is expected that you would use this function in conjunction with a 
+#' It is expected that you would use this function in conjunction with a
 #' call to `lapply` or on a single row.
-#' The function returns a data.frame containing the A score, C score, 
+#' The function returns a data.frame containing the A score, C score,
 #' NPM score and NPM assessment.
-#' 
+#'
 #' @export
 #' @param row, the row from an NPMScore call
 #' @return a data.frame containing A score, C score, NPM score, and NPM assessment for each row
 NPMAssess <- function(row) {
-
-    stopifnot("Score columns not detected. Please ensure you have called NPMScore on your data" = 
-        c("energy_score", "sugar_score", "fat_score", 
-        "protein_score", "fvn_score", "fibre_score","sodium_score") %in% names(row)
+    stopifnot(
+        "Score columns not detected. Please ensure you have called NPMScore on your data" =
+            c(
+                "energy_score", "sugar_score", "fat_score",
+                "protein_score", "fvn_score", "fibre_score", "salt_score"
+            ) %in% names(row)
     )
 
-    A_score <- A_scorer(energy_score = row[['energy_score']],
-                        sugar_score = row[['sugar_score']], 
-                        fat_score = row[['fat_score']], 
-                        sodium_score = row[['sodium_score']])
+    A_score <- A_scorer(
+        energy_score = row[["energy_score"]],
+        sugar_score = row[["sugar_score"]],
+        fat_score = row[["fat_score"]],
+        salt_score = row[["salt_score"]]
+    )
 
-    C_score <- C_scorer(fvn_score = row[['fvn_score']],
-                        protein_score = row[['protein_score']], 
-                        fibre_score = row[['fibre_score']])   
+    C_score <- C_scorer(
+        fvn_score = row[["fvn_score"]],
+        protein_score = row[["protein_score"]],
+        fibre_score = row[["fibre_score"]]
+    )
 
-    NPM_score <- NPM_total(A_score, C_score, row[['fvn_score']], row[['fibre_score']])
+    NPM_score <- NPM_total(A_score, C_score, row[["fvn_score"]], row[["fibre_score"]])
 
-    NPM_assessment <- NPM_assess(NPM_score, row[['product_type']])
+    NPM_assessment <- NPM_assess(NPM_score, row[["product_type"]])
 
-    npm_df <- data.frame("A_score" = A_score, "C_score" = C_score, "NPM_score" = NPM_score, "NPM_assessment" = NPM_assessment, 
-                         stringsAsFactors=FALSE)
+    npm_df <- data.frame(
+        "A_score" = A_score, "C_score" = C_score, "NPM_score" = NPM_score, "NPM_assessment" = NPM_assessment,
+        stringsAsFactors = FALSE
+    )
 
     return(npm_df)
-
 }
 
 #' A score function
-#' 
-#' A scores are defined as the scores for 
-#' energy, sugars, fat and sodium summed together
-#' 
+#'
+#' A scores are defined as the scores for
+#' energy, sugars, fat and salt summed together
+#'
 #' @param energy_score, numeric value for energy score
 #' @param sugar_score, numeric value for sugar score
 #' @param fat_score, numeric value for fat score
-#' @param sodium_score, numeric value for sodium score
+#' @param salt_score, numeric value for salt score
 #' @return a numeric value of the A score
-A_scorer <- function(energy_score, sugar_score, fat_score, sodium_score) {
-    return(sum(energy_score, sugar_score, fat_score, sodium_score))
+A_scorer <- function(energy_score, sugar_score, fat_score, salt_score) {
+    return(sum(energy_score, sugar_score, fat_score, salt_score))
 }
 
 #' C score function
-#' 
+#'
 #' C score is defined as the scores for fruit/veg/nut percentage,
 #' protein and fibre summed together
-#' 
+#'
 #' @param fvn_score, numeric value for fruit/vegetables/nuts percentage score
 #' @param protein_score, numeric value for protein score
 #' @param fibre_score, numeric value for fibre score
@@ -67,46 +72,42 @@ C_scorer <- function(fvn_score, protein_score, fibre_score) {
 }
 
 #' NPM_total
-#' 
+#'
 #' A function to calculate total NPM score
-#' Logic for this function is documented in 
+#' Logic for this function is documented in
 #' [Nutrient Profiling Technical Guidance](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/216094/dh_123492.pdf)
 #' page 6.
-#' 
+#'
 #' @param a_score, a numeric value for the A score
 #' @param c_score, a numeric value for the C score
 #' @param fvn_score, a numeric value for the specific score for fruit/veg/nuts percentage
 #' @param fib_score, a numeric value for the fibre score
 #' @return a numeric value for the overall NPM score
 NPM_total <- function(a_score, c_score, fvn_score, fib_score) {
-
-    npm_score <- if( a_score >= 11 && fvn_score < 5) {
-
+    npm_score <- if (a_score >= 11 && fvn_score < 5) {
         a_score - (fvn_score + fib_score)
-
     } else {
         a_score - c_score
     }
 }
 
 #' NPM Assess function
-#' 
+#'
 #' This function takes an NPM score and returns either "PASS" or "FAIL"
 #' depending on the `type` argument. Where `type` is either "food" or "drink".
-#' 
+#'
 #' @param NPM_score, a numeric value for the NPM score
 #' @param type, a character value of either "food" or "drink" to determine how to assess the score
 #' @returns a character value of either "PASS" or "FAIL"
 NPM_assess <- function(NPM_score, type) {
-
     assessment <- switch(tolower(type),
         "food" = ifelse(NPM_score >= 4, "FAIL", "PASS"),
         "drink" = ifelse(NPM_score >= 1, "FAIL", "PASS"),
         stop(paste0(
             "NPM_assess passed invalid type: ",
-            type))
-            )
+            type
+        ))
+    )
 
     return(assessment)
-
 }

--- a/man/A_scorer.Rd
+++ b/man/A_scorer.Rd
@@ -4,7 +4,7 @@
 \alias{A_scorer}
 \title{A score function}
 \usage{
-A_scorer(energy_score, sugar_score, fat_score, sodium_score)
+A_scorer(energy_score, sugar_score, fat_score, salt_score)
 }
 \arguments{
 \item{energy_score, }{numeric value for energy score}
@@ -13,12 +13,12 @@ A_scorer(energy_score, sugar_score, fat_score, sodium_score)
 
 \item{fat_score, }{numeric value for fat score}
 
-\item{sodium_score, }{numeric value for sodium score}
+\item{salt_score, }{numeric value for salt score}
 }
 \value{
 a numeric value of the A score
 }
 \description{
 A scores are defined as the scores for
-energy, sugars, fat and sodium summed together
+energy, sugars, fat and salt summed together
 }

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -43,4 +43,6 @@ test_that("test full workflow", {
     )
 
     test_data <- cbind(test_data, npm_assess)
+
+    expect_true(is.data.frame(test_data))
 })

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -1,4 +1,4 @@
-test_data <- read.csv(text =  "
+test_data <- read.csv(text = "
 name,brand,product_category,product_type,food_type,drink_format,drink_type,nutrition_info,energy_measurement_kj,energy_measurement_kcal,sugar_measurement_g,fat_measurement_g,salt_measurement_g,sodium_measurement_mg,fibre_measurement_nsp,fibre_measurement_aoac,protein_measurement_g,fruit_nut_measurement_percent,weight_g,volume_ml,volume_water_ml
 lembas,,,Food,,,,,266,,50,3,,0.6,3,,7,0,100,,
 zeno's icecream,,,Food,Ice cream,,,,,24,21,11,0.08,,,0.7,3.5,0,,100,
@@ -13,12 +13,34 @@ bantam water,,,Drink,,Cordial,,Preparation instructions not given,,205,19,0,0.1,
 
 
 test_that("test full workflow", {
-
-    test_data['sg_adjusted'] <- unlist(lapply(seq_len(nrow(test_data)), function(i) SGConverter(test_data[i, ])))
+    test_data["sg_adjusted"] <- unlist(
+        lapply(
+            seq_len(nrow(test_data)),
+            function(i) SGConverter(test_data[i, ])
+        )
+    )
 
     # grateful for help with this function from https://stackoverflow.com/questions/75825126/conditionally-running-a-function-on-a-row-based-on-values-in-another-column-usin/75825163#75825163
 
-    npm_scores <- do.call("rbind", lapply(seq_len(nrow(test_data)), function(i) NPMScore(test_data[i,], sg_adjusted_label="sg_adjusted")))
+    npm_scores <- do.call(
+        "rbind",
+        lapply(
+            seq_len(nrow(test_data)),
+            function(i) NPMScore(test_data[i, ], sg_adjusted_label = "sg_adjusted")
+        )
+    )
 
-    expect_true(is.data.frame(npm_scores))
+    # append NPM Score columns
+    test_data <- cbind(test_data, npm_scores)
+
+    # do an NPM Assessment
+    npm_assess <- do.call(
+        "rbind",
+        lapply(
+            seq_len(nrow(test_data)),
+            function(i) NPMAssess(test_data[i, ])
+        )
+    )
+
+    test_data <- cbind(test_data, npm_assess)
 })

--- a/tests/testthat/test-npm-assess.R
+++ b/tests/testthat/test-npm-assess.R
@@ -10,7 +10,6 @@ test_that("C_score returns the sum of all scores", {
 
 # Test for NPM_total function
 test_that("NPM_total calculates the overall NPM score correctly", {
-
     expect_equal(NPM_total(12, 4, 4, 2), 6)
     expect_equal(NPM_total(10, 5, 2, 1), 5)
 })
@@ -26,39 +25,40 @@ test_that("NPM_assess assesses the NPM score correctly", {
 
 ## testing NPMAssess
 
-assess_row <- data.frame(energy_score = c(5, 3, 4, 6),
-                  sugar_score = c(4,4,6, 5), 
-                  fat_score = c(8,1, 0, 2), 
-                  protein_score = c(4,6,0,2), 
-                  fvn_score = c(0,1, 5, 1), 
-                  fibre_score = c(1,8, 5, 3), 
-                  sodium_score = c(0, 0, 0, 2),
-                  product_type = c("food","food","drink","drink"))
+assess_row <- data.frame(
+    energy_score = c(5, 3, 4, 6),
+    sugar_score = c(4, 4, 6, 5),
+    fat_score = c(8, 1, 0, 2),
+    protein_score = c(4, 6, 0, 2),
+    fvn_score = c(0, 1, 5, 1),
+    fibre_score = c(1, 8, 5, 3),
+    salt_score = c(0, 0, 0, 2),
+    product_type = c("food", "food", "drink", "drink")
+)
 
 # Test 1: Test if the function returns a matrix
 test_that("NPMAssess should return a dataframe", {
-    expect_true(is.data.frame(NPMAssess(assess_row[1,])))
+    expect_true(is.data.frame(NPMAssess(assess_row[1, ])))
 })
 
 # Test 2: Test if the function returns columns named correctly
 test_that("NPMAssess should return a dataframe with columns named correctly", {
-    expect_named(NPMAssess(assess_row[1,]), c("A_score", "C_score", "NPM_score", "NPM_assessment"))
+    expect_named(NPMAssess(assess_row[1, ]), c("A_score", "C_score", "NPM_score", "NPM_assessment"))
 })
 
 # Test 3: Test if the function correctly calculates the NPM score
 test_that("NPMAssess should correctly calculate the NPM score", {
+    out_df <- do.call("rbind", lapply(seq_len(nrow(assess_row)), function(i) NPMAssess(assess_row[i, ])))
 
-    out_df <- do.call("rbind", lapply(seq_len(nrow(assess_row)), function(i) NPMAssess(assess_row[i,])))
-
-    expect_true(identical(out_df$NPM_score, c(16,-7,0,11)))
+    expect_true(identical(out_df$NPM_score, c(16, -7, 0, 11)))
 })
 
 # Test 4: Test if the function correctly assesses the NPM score for a food
 test_that("NPMAssess should correctly assess the NPM score for a food", {
-    expect_equal(NPMAssess(assess_row[2,])$NPM_assessment, "PASS")
+    expect_equal(NPMAssess(assess_row[2, ])$NPM_assessment, "PASS")
 })
 
 # Test 5: Test if the function correctly assesses the NPM score for a drink
 test_that("NPMAssess should correctly assess the NPM score for a drink", {
-    expect_equal(NPMAssess(assess_row[3,])$NPM_assessment, "PASS")
+    expect_equal(NPMAssess(assess_row[3, ])$NPM_assessment, "PASS")
 })


### PR DESCRIPTION
This PR introduces changes to fix #44 by consistently naming the `salt_score` column in NPMAssess so it matches the output of NPMScore.

It also introduces updates to the integration test so that it now properly tests a full pipeline of calls from SGConverter -> NPMScore -> NPMAssess. It does not test anything other than an output is a data.frame but does check that each of these functions hands data to one another without errors.